### PR TITLE
Make `main.py` an executable script

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ mostly because her project is actually usable.
 
 If you decide you want to try this on your machine (not recommended) then the
 current setup is to simply clone the repo and put it somewhere you'll remember.
-Then change the line `status_command i3status` to `status_command python
+Then change the line `status_command i3status` to `status_command 
 [your/path/to/main.py]` in your i3 config file (should be at the bottom). i3bar
 can be reloaded by running `i3-msg reload`. 
 

--- a/main.py
+++ b/main.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import time
 from io import StringIO
 import sys


### PR DESCRIPTION
Hi Dylan,

I'm not sure if you're taking contributions on this project, but I have a small suggestion here that I thought I might as well implement since it wouldn't take too long and you can feel free to close this PR.

By adding this line at the top of `main.py` and adjusting file permissions, the file can be executed using the python interpreter by directly running `./main.py` instead of `python main.py`.

Also, this helped me find a bug in my own project! See [here](https://github.com/Piturnah/gex/issues/20).